### PR TITLE
Including GTSAM_INCLUDE_DIR which isn't found by catkin_simple

### DIFF
--- a/minkindr_gtsam/CMakeLists.txt
+++ b/minkindr_gtsam/CMakeLists.txt
@@ -4,6 +4,8 @@ project(minkindr_gtsam)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
+include_directories(${GTSAM_INCLUDE_DIR})
+
 cs_add_library(${PROJECT_NAME}
 	src/rotation-quaternion-gtsam.cc
 	src/quat-transformation-gtsam.cc


### PR DESCRIPTION
Building under 16.04/Kinetic failed because the compiler couldn't find Manifold.h.  I'm not an expert on catkin_simple, but it looks like it did not automatically find exported GTSAM_INCLUDE_DIR variable from the gtsam_catkin package.